### PR TITLE
Properly unexclude HD content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 addons/[^.]*
-!mm-hd/[^.]*
+!addons/mm-hd/
+addons/mm-hd/.*
 *.uqm


### PR DESCRIPTION
Files under `mm-hd` were being excluded since `mm-hd` as a directory was excluded by `addons/[^.]*`.

(Also, I'm not sure you meant `addons/[^.]*` - that would *include* all dotfiles and *exclude* everything else. Did you mean to exclude `addons/.*` (in which case the `mm-hd` unexclusion shouldn't be needed) or `addons/*`?)