### PR TITLE
Remove erroneous definition of normal space music from Space Music addon

### DIFF
--- a/addons/SpaceMusic/SpaceMusic.rmp
+++ b/addons/SpaceMusic/SpaceMusic.rmp
@@ -1,4 +1,3 @@
-space.music = MUSICRES:addons/SpaceMusic/space.music/space.ogg
 space.druuge.music = MUSICRES:addons/SpaceMusic/space.music/druuge.ogg
 space.ilwrath.music = MUSICRES:addons/SpaceMusic/space.music/ilwrath.ogg
 space.kohrah.music = MUSICRES:addons/SpaceMusic/space.music/kohrah.ogg


### PR DESCRIPTION
The space music addon was defining `space.music` to point to its own `space.music/space.ogg`. This was wrong both because it doesn't (and shouldn't) have its own normal space music and because normal space music is defined by `music.space`, not `space.music` (the first issue probably would've broken normal space music otherwise).