### PR TITLE
Fix gamestrings in HD mode

### DIFF
--- a/addons/classic-pack/gamestrings.txt
+++ b/addons/classic-pack/gamestrings.txt
@@ -1298,6 +1298,14 @@ Calcium Compounds
 Nitric Acid
 
 
+#(Cargo Full)
+Cargo Full
+
+
+#(Data Full)
+Data Full
+
+
 #(MINERAL SCAN) -- SCAN_STRING_BASE
 MINERAL SCAN
 


### PR DESCRIPTION
Not having these strings displaces all the text in HD mode.